### PR TITLE
Add compatibility to latest Express

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -31,6 +31,8 @@
 // External dependencies
 var ld = require('lodash');
 var express = require('express');
+var session = require('express-session');
+var cookieParser = require('cookie-parser');
 var passport = require('passport');
 var localStrategy = require('passport-local').Strategy;
 
@@ -150,12 +152,16 @@ module.exports = (function () {
 
   auth.init = function (app) {
     auth.fn.local();
-    app.use(express.cookieParser());
+    app.use(cookieParser());
     app.use(passport.initialize());
     app.use(passport.session());
     conf.get('sessionSecret', function (err, res) {
       if (err) { throw new Error(err); }
-      app.use(express.session({ secret: res }));
+      app.use(session({
+        secret: res,
+        resave: false,
+        saveUninitialized: true
+      }));
     });
   };
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "browserify": "^9.0.3",
     "docker": "^0.2.14",
     "express": "^3.19.2",
+    "express-session": ">= 1.11.1",
+    "cookie-parser": ">= 1.3.4",
     "jasmine": "^2.2.0",
     "jshint": "^2.6.0",
     "jss": "^1.0.7",


### PR DESCRIPTION
Express unbundled most middleware connectors in their latest version.
See https://github.com/senchalabs/connect#middleware